### PR TITLE
Update LAB_05a_Configure Azure Key Vault networking settings.md

### DIFF
--- a/Instructions/Labs/LAB_05a_Configure Azure Key Vault networking settings.md
+++ b/Instructions/Labs/LAB_05a_Configure Azure Key Vault networking settings.md
@@ -40,7 +40,7 @@ You can use the Azure portal to configure the Azure Key Vault networking setting
    |Subscription|Select your subscription.|
    |Resource group|Enter **az-rg-1.** Select **OK**|
    |**Instance details**|
-   |Key vault name|Enter **AZAPLKeyVault.**|
+   |Key vault name|Enter a unique name|
    |Region|Select **East US**|
    |Pricing tier|System default **Standard**|
    |Days to retain deleted vaults|System default **90**|


### PR DESCRIPTION
key vaults must have a unique name, specifying a predefined value here leads to confusion

# Module: 05
## Lab/Demo: 05a

Fixes # .
using a fixed value leads to an error message, as the name is very likely to be already taken by somebody else globally

Changes proposed in this pull request:
key vaults must have a unique name, specifying a predefined value here leads to confusion
-
-
-